### PR TITLE
Dependencies, visibility and lint

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,68 +1,69 @@
 define openvpn::server(
-  $dev = 'tun0',
-  $ip = '0.0.0.0',
-  $port = '443',
-  $proto = 'tcp',
-  $user = 'openvpn',
-  $group = 'openvpn',
-  $ca = 'keys/ca.crt',
-  $key = 'keys/server.key',
-  $crt = 'keys/server.crt',
-  $dh = 'keys/dh1024.pem',
-  $ipp = false,
-  $ip_pool = [],
+  $dev         = 'tun0',
+  $ip          = '0.0.0.0',
+  $port        = '443',
+  $proto       = 'tcp',
+  $user        = 'openvpn',
+  $group       = 'openvpn',
+  $ca          = 'keys/ca.crt',
+  $key         = 'keys/server.key',
+  $crt         = 'keys/server.crt',
+  $dh          = 'keys/dh1024.pem',
+  $ipp         = false,
+  $ip_pool     = [],
   $compression = 'comp-lzo',
-  $logfile = false,
-  $status_log = "${name}/openvpn-status.log",
-  $verb = 3,
-  $pamlogin = false
+  $logfile     = false,
+  $status_log  = "${name}/openvpn-status.log",
+  $verb        = 3,
+  $pamlogin    = false
 ) {
-
-  package { 'openvpn': 
-    ensure => installed; 
-  }
-
-  # make user the user and group exist
-  # sudo addgroup --system --no-create-home --disabled-login --group openvpn
-  # sudo adduser --system --no-create-home --disabled-login --ingroup openvpn openvpn 
-  group { "${group}":
-    ensure => present,
-    system => true,
-  }
-  user { "${user}":
-    ensure => present,
-    comment => "openvpn user",
-    gid => "${group}",
-    membership => minimum,
-    shell => "/sbin/nologin",
-    home => "/dev/null",
-    require => Group[$group],
-    system => true,
-  }
 
   $tls_server = $proto ? {
     /tcp/   => true,
     default => false
   }
-  
-  file {
+
+  package { 'openvpn':
+    ensure => installed;
+  }
+
+  # make user the user and group exist
+  # sudo addgroup --system --no-create-home --disabled-login --group openvpn
+  # sudo adduser --system --no-create-home --disabled-login \
+  #              --ingroup openvpn openvpn
+  ->group { $group:
+    ensure => present,
+    system => true,
+  }
+  ->user { $user:
+    ensure     => present,
+    comment    => 'openvpn user',
+    gid        => $group,
+    membership => minimum,
+    shell      => '/sbin/nologin',
+    home       => '/dev/null',
+    system     => true,
+  }
+
+  ->file {
     "/etc/openvpn/${name}.conf":
-      owner   => root,
-      group   => root,
-      mode    => '0444',
+      owner   => 'root',
+      group   => 'openvpn',
+      mode    => '0440',
       content => template('openvpn/server.erb');
   }
 
-  file {
+  ->file {
     "/etc/openvpn/${name}":
       ensure  => directory,
       recurse => true,
-      require => Package['openvpn'],
-      owner   => 'root', group => 0, mode => '0755',
+      owner   => 'root',
+      group   => 'openvpn',
+      mode    => '0750',
       source  => "puppet:///openvpn/${name}";
   }
 
-  service {
+  ->service {
     'openvpn':
       ensure      => running,
       enable      => true,


### PR DESCRIPTION
Fixed a bug that the service is started before the configuration files have been created

Reduced the visibility of keys and configuration

Fixed warnings by puppet-lint
